### PR TITLE
feat: implement memo CRUD API

### DIFF
--- a/src/app/api/memos/[id]/route.ts
+++ b/src/app/api/memos/[id]/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { id } = params;
+    const data = await req.json();
+    const { title, content } = data;
+
+    // メモの存在確認
+    const existingMemo = await prisma.memo.findUnique({
+      where: { id: parseInt(id) },
+    });
+
+    if (!existingMemo) {
+      return NextResponse.json({ error: "Memo not found" }, { status: 404 });
+    }
+
+    // メモを更新
+    const updatedMemo = await prisma.memo.update({
+      where: { id: parseInt(id) },
+      data: { title, content },
+    });
+
+    return NextResponse.json(updatedMemo);
+  } catch (error) {
+    console.error("Error updating memo:", error);
+    return NextResponse.json(
+      { error: "Failed to update memo" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { id } = params;
+
+    // メモの存在確認
+    const existingMemo = await prisma.memo.findUnique({
+      where: { id: parseInt(id) },
+    });
+
+    if (!existingMemo) {
+      return NextResponse.json({ error: "Memo not found" }, { status: 404 });
+    }
+
+    // メモを削除
+    await prisma.memo.delete({
+      where: { id: parseInt(id) },
+    });
+
+    return NextResponse.json(
+      { message: "Memo deleted successfully" },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error deleting memo:", error);
+    return NextResponse.json(
+      { error: "Failed to delete memo" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/memos/route.ts
+++ b/src/app/api/memos/route.ts
@@ -1,7 +1,41 @@
-import { NextResponse } from 'next/server';
-import prisma from '@/lib/prisma';
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
 
 export async function GET() {
-  const memos = await prisma.memo.findMany();
-  return NextResponse.json(memos);
+  try {
+    const memos = await prisma.memo.findMany();
+    return NextResponse.json(memos);
+  } catch (error) {
+    console.error("Error fetching memos:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch memos" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    const { title, content } = data;
+
+    if (!title || !content) {
+      return NextResponse.json(
+        { error: "Title and content are required" },
+        { status: 400 }
+      );
+    }
+
+    const memo = await prisma.memo.create({
+      data: { title, content },
+    });
+
+    return NextResponse.json(memo);
+  } catch (error) {
+    console.error("Error creating memo:", error);
+    return NextResponse.json(
+      { error: "Failed to create memo" },
+      { status: 500 }
+    );
+  }
 }


### PR DESCRIPTION
## PR内容

###  概要

メモCRUD API（作成・取得・更新・削除）を実装。

---

### 目的

- メモアプリで必要なCRUD操作をサーバーサイドAPIとして用意するため  
- フロントエンドからAPI経由でメモデータを操作できるようにするため

---

